### PR TITLE
Theme homepage with Johns Hopkins colors and champion icon

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,9 @@
 @tailwind utilities;
 
 :root { color-scheme: light dark }
-body { @apply bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100; }
+body { @apply bg-jhu-blue text-white; }
 .container { @apply mx-auto max-w-5xl px-4; }
-.card { @apply rounded-2xl shadow p-4 bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800; }
-.btn { @apply inline-flex items-center gap-2 rounded-xl px-3 py-2 border border-zinc-300 dark:border-zinc-700; }
+.card { @apply rounded-2xl shadow p-4 bg-white text-jhu-blue border border-jhu-gold; }
+.btn { @apply inline-flex items-center gap-2 rounded-xl px-3 py-2 border border-jhu-gold; }
 .table { @apply w-full text-sm; }
-.table th, .table td { @apply px-3 py-2 border-b border-zinc-200 dark:border-zinc-800; }
+.table th, .table td { @apply px-3 py-2 border-b border-jhu-gold; }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { Trophy } from "lucide-react";
 
 async function getHighlights() {
   const latestWeek = await prisma.week.findFirst({ orderBy: { number: "desc" } });
@@ -13,39 +14,47 @@ async function getHighlights() {
   return { latestWeek, top, posts, threads };
 }
 
+const LAST_YEAR_CHAMPION = "Alpha FC";
+
 export default async function HomePage() {
   const { latestWeek, top, posts, threads } = await getHighlights();
   return (
-    <div className="grid md:grid-cols-2 gap-6">
-      <div className="card">
-        <h2 className="text-lg font-semibold mb-2">Top Scorers {latestWeek ? `(Week ${latestWeek.number})` : ""}</h2>
-        <ul className="space-y-1">
-          {top.length === 0 && <li className="text-sm text-zinc-500">No data yet.</li>}
-          {top.map((s) => (
-            <li key={s.id} className="flex justify-between">
-              <span>{s.team.name}</span>
-              <span className="font-mono">{Number(s.points).toFixed(2)}</span>
-            </li>
-          ))}
-        </ul>
+    <div className="space-y-6">
+      <div className="flex flex-col items-center">
+        <Trophy className="w-32 h-32 text-jhu-gold" />
+        <p className="mt-4 text-2xl font-bold text-center">{`Last Year's Champion: ${LAST_YEAR_CHAMPION}`}</p>
       </div>
-      <div className="card">
-        <h2 className="text-lg font-semibold mb-2">Latest Posts</h2>
-        <ul className="list-disc ml-4">
-          {posts.map(p => <li key={p.id}>{p.title}</li>)}
-          {posts.length === 0 && <li className="text-sm text-zinc-500">No posts yet.</li>}
-        </ul>
-      </div>
-      <div className="card">
-        <h2 className="text-lg font-semibold mb-2">Active Threads</h2>
-        <ul className="list-disc ml-4">
-          {threads.map(t => <li key={t.id}>{t.title}</li>)}
-          {threads.length === 0 && <li className="text-sm text-zinc-500">No threads yet.</li>}
-        </ul>
-      </div>
-      <div className="card">
-        <h2 className="text-lg font-semibold mb-2">Awards (Latest Week)</h2>
-        <p className="text-sm text-zinc-500">Populate via the awards engine after ingest.</p>
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="card">
+          <h2 className="text-lg font-semibold mb-2">Top Scorers {latestWeek ? `(Week ${latestWeek.number})` : ""}</h2>
+          <ul className="space-y-1">
+            {top.length === 0 && <li className="text-sm text-jhu-blue/70">No data yet.</li>}
+            {top.map((s) => (
+              <li key={s.id} className="flex justify-between">
+                <span>{s.team.name}</span>
+                <span className="font-mono">{Number(s.points).toFixed(2)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="card">
+          <h2 className="text-lg font-semibold mb-2">Latest Posts</h2>
+          <ul className="list-disc ml-4">
+            {posts.map(p => <li key={p.id}>{p.title}</li>)}
+            {posts.length === 0 && <li className="text-sm text-jhu-blue/70">No posts yet.</li>}
+          </ul>
+        </div>
+        <div className="card">
+          <h2 className="text-lg font-semibold mb-2">Active Threads</h2>
+          <ul className="list-disc ml-4">
+            {threads.map(t => <li key={t.id}>{t.title}</li>)}
+            {threads.length === 0 && <li className="text-sm text-jhu-blue/70">No threads yet.</li>}
+          </ul>
+        </div>
+        <div className="card">
+          <h2 className="text-lg font-semibold mb-2">Awards (Latest Week)</h2>
+          <p className="text-sm text-jhu-blue/70">Populate via the awards engine after ingest.</p>
+        </div>
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,12 @@ const config: Config = {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "jhu-blue": "#002D72",
+        "jhu-gold": "#C99700",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Apply Johns Hopkins blue and gold color palette across site styling
- Highlight last year's champion with a prominent trophy icon on the home page

## Testing
- `npm test` (fails: Missing script: "test")
- `DATABASE_URL="file:./dev.db" npm run build` (fails: Type error in src/lib/auth.ts)


------
https://chatgpt.com/codex/tasks/task_e_6899069e082883289ab7769b964caefd